### PR TITLE
Handle empty content in Mercury response

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -174,7 +174,7 @@ async function generate() {
 async function fetchText(urls = []) {
   var contents = urls.map(async u => {
     var res = await Mercury.parse(u, {contentType: 'text'})
-    return res.content.trim()
+    return (res.content || '').trim()
   })
 
   return Promise.all(contents).then(c => c.join(''))


### PR DESCRIPTION
The CLI script was blowing up when it got an empty `content` in the Mercury response. This makes sure we at least have an empty string in that case.

Closes #7